### PR TITLE
feat: rotate door on open with audio

### DIFF
--- a/Assets/Scripts/Interactions/DoorInteractable.cs
+++ b/Assets/Scripts/Interactions/DoorInteractable.cs
@@ -5,13 +5,22 @@ public class DoorInteractable : MonoBehaviour, IInteractable, ILoopResettable
     [SerializeField] private bool isLocked;
     [SerializeField] private bool isOpen;
     [SerializeField] private GameObject doorObject;
+    [SerializeField] private float openZRotation = 90f;
+    [SerializeField] private AudioSource audioSource;
+    [SerializeField] private AudioClip openSound;
 
     private bool startIsOpen;
+    private Transform doorTransform;
+    private Quaternion originalRotation;
 
     private void Awake()
     {
         if (doorObject == null && transform.childCount > 0)
             doorObject = transform.GetChild(0).gameObject;
+
+        doorTransform = doorObject != null ? doorObject.transform : transform;
+        if (doorTransform != null)
+            originalRotation = doorTransform.localRotation;
 
         startIsOpen = isOpen;
         ApplyState(isOpen);
@@ -37,9 +46,19 @@ public class DoorInteractable : MonoBehaviour, IInteractable, ILoopResettable
 
     private void ApplyState(bool open)
     {
+        bool wasOpen = isOpen;
         isOpen = open;
 
-        if (doorObject != null)
-            doorObject.SetActive(!open);
+        if (doorTransform != null)
+        {
+            Quaternion targetRotation = originalRotation;
+            if (open)
+                targetRotation = originalRotation * Quaternion.Euler(0f, 0f, openZRotation);
+
+            doorTransform.localRotation = targetRotation;
+        }
+
+        if (open && !wasOpen && audioSource != null && openSound != null)
+            audioSource.PlayOneShot(openSound);
     }
 }


### PR DESCRIPTION
## Summary
- rotate the door interactable instead of disabling the mesh when toggling states
- serialize a configurable Z rotation for the open state and restore the original orientation on loop reset
- trigger a serialized audio clip through an audio source when the door first opens

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e512d913508330bd3f1e2180c91d62