### PR TITLE
Add door close sound playback to DoorInteractable

### DIFF
--- a/Assets/Scripts/Interactions/DoorInteractable.cs
+++ b/Assets/Scripts/Interactions/DoorInteractable.cs
@@ -10,6 +10,7 @@ public class DoorInteractable : MonoBehaviour, IInteractable, ILoopResettable
     [SerializeField] private float rotationDuration = 0.5f;
     [SerializeField] private AudioSource audioSource;
     [SerializeField] private AudioClip openSound;
+    [SerializeField] private AudioClip closeSound;
 
     private bool startIsOpen;
     private Transform doorTransform;
@@ -74,8 +75,17 @@ public class DoorInteractable : MonoBehaviour, IInteractable, ILoopResettable
             }
         }
 
-        if (open && !wasOpen && audioSource != null && openSound != null)
-            audioSource.PlayOneShot(openSound);
+        if (audioSource != null)
+        {
+            if (open && !wasOpen && openSound != null)
+            {
+                audioSource.PlayOneShot(openSound);
+            }
+            else if (!open && wasOpen && closeSound != null)
+            {
+                audioSource.PlayOneShot(closeSound);
+            }
+        }
     }
 
     private IEnumerator RotateDoor(Quaternion targetRotation)


### PR DESCRIPTION
## Summary
- add a serialized close sound clip to `DoorInteractable`
- play the configured close sound when the door transitions from open to closed

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68e52df2f13c8330a22238a0909dc27e